### PR TITLE
Export retention information

### DIFF
--- a/whisper.go
+++ b/whisper.go
@@ -137,7 +137,7 @@ type Whisper struct {
 	Create a new Whisper database file and write it's header.
 */
 func Create(path string, retentions Retentions, aggregationMethod AggregationMethod, xFilesFactor float32) (whisper *Whisper, err error) {
-	sort.Sort(retentionsByPrecision{retentions})
+	sort.Sort(RetentionsByPrecision{retentions})
 	if err = validateRetentions(retentions); err != nil {
 		return nil, err
 	}
@@ -292,6 +292,23 @@ func (whisper *Whisper) Size() int {
 */
 func (whisper *Whisper) MetadataSize() int {
 	return MetadataSize + (ArchiveInfoSize * len(whisper.archives))
+}
+
+/*
+  Retentions returns a Retentions type which lists each archive's retention
+  in this Whisper file.  A deep copy so that the internal data structure
+  remains safe.
+*/
+func (whisper *Whisper) Retentions() (retentions Retentions) {
+	retentions = make(Retentions, 0)
+	for _, v := range whisper.archives {
+		r := new(Retention)
+		r.secondsPerPoint = v.Retention.secondsPerPoint
+		r.numberOfPoints = v.Retention.numberOfPoints
+		retentions = append(retentions, r)
+	}
+
+	return retentions
 }
 
 /*
@@ -642,6 +659,14 @@ func (retention *Retention) Size() int {
 	return retention.numberOfPoints * PointSize
 }
 
+func (retention *Retention) SecondsPerPoint() int {
+	return retention.secondsPerPoint
+}
+
+func (retention *Retention) NumberOfPoints() int {
+	return retention.numberOfPoints
+}
+
 type Retentions []*Retention
 
 func (r Retentions) Len() int {
@@ -652,10 +677,14 @@ func (r Retentions) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
 }
 
-type retentionsByPrecision struct{ Retentions }
+type RetentionsByPrecision struct{ Retentions }
 
-func (r retentionsByPrecision) Less(i, j int) bool {
+func (r RetentionsByPrecision) Less(i, j int) bool {
 	return r.Retentions[i].secondsPerPoint < r.Retentions[j].secondsPerPoint
+}
+
+func (r RetentionsByPrecision) Iterator() Retentions {
+	return r.Retentions
 }
 
 /*

--- a/whisper_test.go
+++ b/whisper_test.go
@@ -63,7 +63,7 @@ func TestParseRetentionDefs(t *testing.T) {
 
 func TestSortRetentions(t *testing.T) {
 	retentions := Retentions{{300, 12}, {60, 30}, {1, 300}}
-	sort.Sort(retentionsByPrecision{retentions})
+	sort.Sort(RetentionsByPrecision{retentions})
 	if retentions[0].secondsPerPoint != 1 {
 		t.Fatalf("Retentions array is not sorted")
 	}
@@ -226,6 +226,29 @@ func TestOpenFile(t *testing.T) {
 
 	if result1.String() != result2.String() {
 		t.Fatalf("Results do not match")
+	}
+
+	tearDown()
+}
+
+func TestGetRetentions(t *testing.T) {
+	path, _, retentions, tearDown := setUpCreate()
+	wsp, err := Create(path, retentions, Average, 0.5)
+	if err != nil {
+		t.Errorf("Failed to create: %v", err)
+	}
+	defer wsp.Close()
+	archiveList := wsp.Retentions()
+	if len(archiveList) != len(retentions) {
+		t.Fatalf("Returned retentions is not the same length as inital retentions")
+	}
+	for i, _ := range retentions {
+		if retentions[i].secondsPerPoint != archiveList[i].SecondsPerPoint() {
+			t.Fatalf("Retention's secondsPerPoint do not match")
+		}
+		if retentions[i].numberOfPoints != archiveList[i].NumberOfPoints() {
+			t.Fatalf("Retention's numberOfPoints do not match")
+		}
 	}
 
 	tearDown()


### PR DESCRIPTION
Return information about the archives' retentions in an existing whisper
DB file.  Also export RetentionsByPrecision so that a caller can sort
retentions as well.  Support iteration, and exposing useful attributes.

This makes it possible to write a Go implementation of whisper-fill.py.