### PR TITLE
TimeSeries.Points() should return []*TimeSeriesPoint

### DIFF
--- a/whisper.go
+++ b/whisper.go
@@ -713,10 +713,10 @@ func (ts *TimeSeries) Values() []float64 {
 	return ts.values
 }
 
-func (ts *TimeSeries) Points() []TimeSeriesPoint {
-	points := make([]TimeSeriesPoint, len(ts.values))
+func (ts *TimeSeries) Points() []*TimeSeriesPoint {
+	points := make([]*TimeSeriesPoint, len(ts.values))
 	for i, value := range ts.values {
-		points[i] = TimeSeriesPoint{Time: ts.fromTime + ts.step*i, Value: value}
+		points[i] = &TimeSeriesPoint{Time: ts.fromTime + ts.step*i, Value: value}
 	}
 	return points
 }


### PR DESCRIPTION
Make this function consistent with the rest of the code base that deals
with slices of pointers.