### PR TITLE
Fix bug: UpdateMany saves not last point if many points has identical…

### DIFF
--- a/whisper.go
+++ b/whisper.go
@@ -338,9 +338,20 @@ func (whisper *Whisper) Update(value float64, timestamp int) (err error) {
 	return nil
 }
 
+func reversePoints(points []*TimeSeriesPoint) {
+	size := len(points)
+	end := size / 2
+
+	for i := 0; i < end; i++ {
+		points[i], points[size-i-1] = points[size-i-1], points[i]
+	}
+}
+
 func (whisper *Whisper) UpdateMany(points []*TimeSeriesPoint) {
 	// sort the points, newest first
-	sort.Sort(timeSeriesPointsNewestFirst{points})
+
+	reversePoints(points)
+	sort.Stable(timeSeriesPointsNewestFirst{points})
 
 	now := int(time.Now().Unix()) // TODO: danger of 2030 something overflow
 
@@ -351,9 +362,7 @@ func (whisper *Whisper) UpdateMany(points []*TimeSeriesPoint) {
 			continue
 		}
 		// reverse currentPoints
-		for i, j := 0, len(currentPoints)-1; i < j; i, j = i+1, j-1 {
-			currentPoints[i], currentPoints[j] = currentPoints[j], currentPoints[i]
-		}
+		reversePoints(currentPoints)
 		whisper.archiveUpdateMany(&archive, currentPoints)
 
 		if len(points) == 0 { // nothing left to do

--- a/whisper_test.go
+++ b/whisper_test.go
@@ -566,3 +566,31 @@ func TestTimeSeriesPoints(t *testing.T) {
 		t.Fatalf("Unexpected number of points in time series, %v", length)
 	}
 }
+
+func TestUpdateManyWithEqualTimestamp(t *testing.T) {
+	now := int(time.Now().Unix())
+	points := []*TimeSeriesPoint{}
+
+	// add points
+	// now timestamp: 0,99,2,97,...,3,99,1
+	// now-1 timestamp: 100,1,98,...,97,2,99
+
+	for i := 0; i < 100; i++ {
+		if i%2 == 0 {
+			points = append(points, &TimeSeriesPoint{now, float64(i)})
+			points = append(points, &TimeSeriesPoint{now - 1, float64(100 - i)})
+		} else {
+			points = append(points, &TimeSeriesPoint{now, float64(100 - i)})
+			points = append(points, &TimeSeriesPoint{now - 1, float64(i)})
+		}
+	}
+
+	result := testCreateUpdateManyFetch(t, Average, 0.5, points, 2, 10)
+
+	if result.values[0] != 99.0 {
+		t.Fatalf("Incorrect saved value. Expected %v, received %v", 99.0, result.values[0])
+	}
+	if result.values[1] != 1.0 {
+		t.Fatalf("Incorrect saved value. Expected %v, received %v", 1.0, result.values[1])
+	}
+}


### PR DESCRIPTION
… timestamp

Python code from whisper.py
```
points.sort(key=lambda p: p[0], reverse=True)
```
not equals
```
sort.Sort(timeSeriesPointsNewestFirst{points})
```

It equals reverse + Sort(timeSeriesPointsNewestFirst... And use sort.Stable for guarantee the preservation of order