### PR TITLE
Allow reading of whisper files without write permission

### DIFF
--- a/whisper.go
+++ b/whisper.go
@@ -222,6 +222,9 @@ func validateRetentions(retentions Retentions) error {
 */
 func Open(path string) (whisper *Whisper, err error) {
 	file, err := os.OpenFile(path, os.O_RDWR, 0666)
+	if os.IsPermission(err) {
+		file, err = os.OpenFile(path, os.O_RDONLY, 0666)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows me to run tools against my Whisper files without being the owner and avoids accidental modification.

If there's interest here I can work out locking so we use shared locks in this case instead of exclusive.